### PR TITLE
Update Feedback to increase /dev/shm

### DIFF
--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -21,6 +21,7 @@ x-feedback: &feedback
 services:
   feedback-lite:
     <<: *feedback
+    shm_size: 128m
 
   feedback-app: &feedback-app
     <<: *feedback


### PR DESCRIPTION
Jasmine tests were consistently crashing. Research led to increasing the size for /dev/shm fixes the issue.

See https://stackoverflow.com/questions/53902507/unknown-error-session-deleted-because-of-page-crash-from-unknown-error-cannot#comment125897307_68557764