### PR TITLE
Fix ambigious argument error

### DIFF
--- a/bin/branch_checks.sh
+++ b/bin/branch_checks.sh
@@ -38,7 +38,7 @@ if ! git -C "${govuk_root_dir}/${app}" status -sb | grep 'origin/' -q; then
   exit 0
 fi
 
-origin_head_commit=$(git -C "${govuk_root_dir}/${app}" rev-parse "@{u}")
+origin_head_commit=$(git -C "${govuk_root_dir}/${app}" rev-parse --"@{u}")
 
 update_branch=${GOVUK_DOCKER_UPDATE_BRANCH:-ask}
 


### PR DESCRIPTION
Running make on a repo that needs to be checked outputs:

```
fatal: ambiguous argument '@{u}': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```